### PR TITLE
Dashboard

### DIFF
--- a/gerrit-rest.el
+++ b/gerrit-rest.el
@@ -223,6 +223,19 @@ A comment MESSAGE can be provided."
             (message "Setting Verify-vote %s for %s" vote changenr)
             (gerrit-rest-change-verify changenr vote message))))
 
+(defun gerrit-rest-change-query (expression)
+  "Return information about changes that match EXPRESSION."
+  (interactive "sEnter a search expression: ")
+  (let ((req (concat (format "/changes/?q=%s&" expression)
+                     "o=CURRENT_REVISION&"
+                     "o=CURRENT_COMMIT&"
+                     "o=LABELS"
+                     ;; "o=DETAILED_LABELS"
+                     ;; "o=DETAILED_ACCOUNTS"))
+                     ))
+        (json-array-type 'list))
+    (gerrit-rest-sync "GET" nil req)))
+
 (provide 'gerrit-rest)
 
 ;;; gerrit-rest.el ends here

--- a/gerrit-rest.el
+++ b/gerrit-rest.el
@@ -118,11 +118,12 @@ down the URL structure to send the request."
          (req (format fmtstr topicname)))
     (gerrit-rest-sync "GET" nil req)))
 
-(defun gerrit-rest--get-gerrit-usernames ()
-  "Return a list of usernames of all active gerrit users."
+(defun gerrit-rest--get-gerrit-accounts ()
+  "Return a list of cons cells of all active gerrit users."
   (interactive)
   (condition-case nil
-      (mapcar (lambda (account-info) (cdr (assoc 'username (cdr account-info))))
+      (mapcar (lambda (account-info) (cons (cdr (assoc '_account_id account-info))
+                                      (cdr (assoc 'username account-info))))
               (let ((json-array-type 'list))
                 ;; see https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html
                 ;; and https://gerrit-review.googlesource.com/Documentation/user-search-accounts.html#_search_operators

--- a/gerrit.el
+++ b/gerrit.el
@@ -401,18 +401,16 @@ gerrit-upload: (current cmd: %(concat (gerrit-upload-create-git-review-cmd)))
 ;; dashboard
 
 (defun gerrit--combined-level-to-numberstr (combined-label verify)
-  (interactive)
-  (if verify
-      (pcase combined-label
-        ('approved "+1")
-        ('rejected "-1")
-        (default ""))
-    (pcase combined-label
-      ('approved "+2")
-      ('recommended "+1")
-      ('disliked "-1")
-      ('rejected "-2")
-      (default ""))))
+  (or (if verify
+          (pcase combined-label
+            ('approved "+1")
+            ('rejected "-1"))
+        (pcase combined-label
+          ('approved "+2")
+          ('recommended "+1")
+          ('disliked "-1")
+          ('rejected "-2")))
+      ""))
 
 (defun gerrit-dashboard--get-data (expression)
   (gerrit--init-accounts)


### PR DESCRIPTION
This adds a simple dashboard, implemented using `tabulated-list-mode`, that displays the results of the query `gerrit-dashboard-query`.