### PR TITLE
Make gerrit-get-current-project handle all types of Git URLs

### DIFF
--- a/gerrit.el
+++ b/gerrit.el
@@ -538,14 +538,18 @@ The prefix magit- prefix is required by `magit-insert-section'.")
 (defun gerrit-get-current-project ()
   "Return the gerrit project name, e.g., 'software/jobdeck'."
   (interactive)
-  (let ((remote-url (car
-                     (magit-config-get-from-cached-list
-                      (format "remote.%s.url" (gerrit-get-remote))))))
-    (if (s-starts-with? "https://" remote-url)
-        (nth 2 (s-split-up-to "/" remote-url 3 t)) ;; return the endpoint (everything after the 3rd /)
-      (s-chop-suffix
-       ".git"
-       (nth 1 (s-split ":" remote-url))))))
+  (let* ((remote-url (car
+                      (magit-config-get-from-cached-list
+                       (format "remote.%s.url" (gerrit-get-remote)))))
+		 (parsed-url (url-generic-parse-url remote-url))
+		 (parsed-path (url-filename parsed-url)))
+	(cond ((not (string= remote-url parsed-path)) ; Any URL with scheme:// AND scp-like w/o username
+		   (replace-regexp-in-string "^/?\\(.*?\\)\\(\\.git/?\\)?$" "\\1"
+									 parsed-path))
+		  ((string-match "^\\(?:[^@]+@\\)?[^:]+:\\(.*?\\)\\(?:\\.git/?\\)?$" remote-url) ; scp-like
+		   ;; the matching regex is very generous, assume the URL is correct
+		   (match-string 1 remote-url))
+		  (t (error "Remote URL %s is not recognized" remote-url)))))
 
 (defun gerrit-get-changeid-from-current-commit ()
   "Determine the change-id from the current commit.

--- a/test/gerrit.el-test.el
+++ b/test/gerrit.el-test.el
@@ -1,18 +1,42 @@
 ;;; gerrit.el-test.el --- Tests for gerrit.el -*- lexical-binding: t; -*-
 
+;;; Code:
+
 (require 'cl-lib)
 
 (require 'gerrit)
 
 
 (ert-deftest gerrit-test-get-current-project ()
-  (cl-letf (((symbol-function 'magit-config-get-from-cached-list)
-             (lambda (&rest _) `("https://review.gerrithub.io/parent/pro1"))))
-    (should (equal (call-interactively #'gerrit-get-current-project) "parent/pro1")))
-
-  (cl-letf (((symbol-function 'magit-config-get-from-cached-list)
-             (lambda (&rest _) `("git@review.gerrithub.io:parent/pro2.git"))))
-    (should (equal (call-interactively #'gerrit-get-current-project) "parent/pro2"))))
+  (let ((test-pairs
+		 '(;; ssh
+		   ("ssh://user@review.gerrithub.io/parent/ssh1.git/" . "parent/ssh1")
+		   ("ssh://user@review.gerrithub.io:443/parent/ssh2.git" . "parent/ssh2")
+		   ("ssh://review.gerrithub.io:443/parent/ssh3" . "parent/ssh3")
+		   ("ssh://review.gerrithub.io/parent/ssh4" . "parent/ssh4")
+		   ;; git
+		   ("git://review.gerrithub.io:443/parent/git1" . "parent/git1")
+		   ("git://review.gerrithub.io/parent/git2.git" . "parent/git2")
+		   ;; http[s]
+		   ("https://review.gerrithub.io/parent/http1" . "parent/http1")
+		   ("https://review.gerrithub.io:80/parent/http2" . "parent/http2")
+		   ("http://review.gerrithub.io/parent/http3" . "parent/http3")
+		   ("http://review.gerrithub.io:80/parent/http4" . "parent/http4")
+		   ;; ftp[s]
+		   ("ftps://review.gerrithub.io/parent/ftp1" . "parent/ftp1")
+		   ("ftps://review.gerrithub.io:80/parent/ftp2.git" . "parent/ftp2")
+		   ("ftp://review.gerrithub.io/parent/ftp3.git/" . "parent/ftp3")
+		   ("ftp://review.gerrithub.io:80/parent/ftp4" . "parent/ftp4")
+		   ;; scp-like
+		   ("git@review.gerrithub.io:parent/scp1.git" . "parent/scp1")
+		   ("review.gerrithub.io:parent/scp2.git" . "parent/scp2")
+		   )))
+	(cl-loop for (git-url . project) in test-pairs
+			 do
+			 (cl-letf (((symbol-function 'magit-config-get-from-cached-list)
+						(lambda (&rest _) `(,git-url))))
+			   (ert-info ((format "Project for %s should be %s" git-url project))
+				 (should (equal (call-interactively #'gerrit-get-current-project) project)))))))
 
 (ert-deftest gerrit-test-alist-rec-get ()
   (should (equal (gerrit--alist-get-recursive 'A 'B '((A . ((B . 3)))))


### PR DESCRIPTION
Use url-generic-parse-url to parse the remote URL except for the
special scp-like URL USER@HOST:PATH.