### PR TITLE
Update README with authentication clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ machine gerrithostname.org
     login my-gerrit-username
     password xxxx
 ```
+Note: Gerrit's HTTP basic authentication expects the HTTP password from the user’s account settings page. Make sure to generate one, copy it and add it as the password in your auth-source.
 
 ### Keyring
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ machine gerrithostname.org
     login my-gerrit-username
     password xxxx
 ```
-Note: Gerrit's HTTP basic authentication expects the HTTP password from the user’s account settings page. Make sure to generate one, copy it and add it as the password in your auth-source.
+Note: Depending on your auth configuration, Gerrit may expect a generated HTTP password (ex. if you have `git_basic_auth_policy="HTTP_LDAP"`). If there is an HTTP credentials section in your user's account settings page, then an HTTP password needs to be generated and supplied in your auth-source file.
 
 ### Keyring
 


### PR DESCRIPTION
Added clarification that the password is the HTTP password generated in the user account settings.