### PR TITLE
Add gerrit-download-transient

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Now you can list the secrets using `secrets-show-secrets`.
 
 **TODO** extend/finalize this documentation.
 
+## News
+
+October 2021:
+
+* Add a new transient called `gerrit-download-transient`, which will replace
+the `gerrit-download` function in the future.
+
 ## Screenshots
 
 ![gerrit-dashboard](https://user-images.githubusercontent.com/206581/88588506-f8048780-d057-11ea-9c57-ac2a58aadd58.png)

--- a/gerrit.el
+++ b/gerrit.el
@@ -1234,22 +1234,20 @@ gerrit-upload: (current cmd: %(concat (gerrit-upload-create-git-review-cmd)))
   :key "b"
   :argument "branch=")
 
-(defun gerrit-download:--in-current-repo (changenr &optional args)
+(defun gerrit-download:--in-current-repo (changenr)
   (interactive
-   (let ((targs (transient-args 'gerrit-download-transient)))
-     (list
-      (gerrit--select-change-from-matching-changes
-       ;; create a filter that matches only changes for the current project
-       ;; and for the selected (if any) branch
-       (concat "status:open"
-               " project:" (gerrit-get-current-project)
-                (car (cl-loop for arg in targs collect
+   (list
+    (gerrit--select-change-from-matching-changes
+     ;; create a filter that matches only changes for the current project
+     ;; and for the selected (if any) branch
+     (concat "status:open"
+             " project:" (gerrit-get-current-project)
+             (car (cl-loop for arg in (transient-args 'gerrit-download-transient) collect
                            (cond ((s-starts-with? "branch=" arg)
                                   (concat " branch:" (s-chop-prefix "branch=" arg)))
                                  ;; TODO add support for other filter options
                                  (t
-                                  nil))))))
-      tags)))
+                                  nil))))))))
   ;; (message "CR: %s, %s" changenr args))
   (gerrit-download--new changenr))
 

--- a/gerrit.el
+++ b/gerrit.el
@@ -1235,6 +1235,7 @@ gerrit-upload: (current cmd: %(concat (gerrit-upload-create-git-review-cmd)))
   :argument "branch=")
 
 (defun gerrit-download:--in-current-repo (changenr)
+  "Download a gerrit change CHANGENR for the current project into the current workspace."
   (interactive
    (list
     (gerrit--select-change-from-matching-changes
@@ -1248,7 +1249,6 @@ gerrit-upload: (current cmd: %(concat (gerrit-upload-create-git-review-cmd)))
                                  ;; TODO add support for other filter options
                                  (t
                                   nil))))))))
-  ;; (message "CR: %s, %s" changenr args))
   (gerrit-download--new changenr))
 
 (transient-define-prefix gerrit-download-transient ()


### PR DESCRIPTION
This adds an initial version of the gerrit-download transient, which
currently does the same as the `gerrit-upload` command, but it allows
you to select a branch in the query that is used for displaying the
changes. As a next step, support for downloading changes from other
repos, i.e., not the current one, will be added.

Change-Id: I91c74b4f1e44330d00a014b04b744b5e9c52d798