### PR TITLE
Add support for downloading changes for different projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Gerrit is a great code review tool and a great git hosting serivce. This
 package provides an emacs interface for
 
 * uploading changes (`gerrit-upload`)
-* downloading changes (`gerrit-download`)
+* downloading changes (`gerrit-download` and `gerrit-download-transient`)
 * creating a dashboard  (`gerrit-dashboard`)
 * creating buffers that contain details about gerrit topics an gerrit
   changes (`gerrit-section-topic-info` and `gerrit-section-change-info`).
@@ -114,7 +114,9 @@ Now you can list the secrets using `secrets-show-secrets`.
 October 2021:
 
 * Add a new transient called `gerrit-download-transient`, which will replace
-the `gerrit-download` function in the future.
+  the `gerrit-download` function in the future.
+* Add support for downloading changes in arbitrary git workspaces using
+  `gerrit-download-transient`.
 
 ## Screenshots
 


### PR DESCRIPTION
Now it is possible to download a change for a project, which is not the
current one, i.e., to download a change for project B you don't have to
be in the workspace of project B to download it.

A new key (k) was added to the gerrit-download-transient to download
changes for known projects.

This implementes the first part of #19 

Change-Id: Ie4d55bced47af0575fce3a4a01aea6e0345771e1