### PR TITLE
Use url-hexify-string in gerrit-rest--escape-project

### DIFF
--- a/gerrit-rest.el
+++ b/gerrit-rest.el
@@ -110,8 +110,8 @@ down the URL structure to send the request."
                                 "*gerrit-rest-status* buffer for more information")))))))))))
 
 (defun gerrit-rest--escape-project (project)
-  "Escape project name PROJECT for usage in REST API requets."
-  (s-replace-all '(("/" . "%2F")) project))
+  "Escape project name PROJECT for usage in REST API requests."
+  (url-hexify-string project))
 
 (defun gerrit-rest-get-server-version ()
   "Return the gerrit server version."


### PR DESCRIPTION
Use url-hexify-string instead of adding characters as they are found to be problems.
The entire function could be replaced, but it might be good to have this hook in the future.